### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/contracts": "~5.5",
-        "illuminate/support": "~5.5",
+        "illuminate/contracts": "5.5.*",
+        "illuminate/support": "5.5.*",
         "predis/predis": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.